### PR TITLE
[HIG-3475] add TRPC compatible error handler

### DIFF
--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -20,6 +20,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@trpc/server": "^10.6.0",
 		"error-stack-parser": "2.0.7",
 		"graphql": "15",
 		"graphql-request": "3.7.0",

--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -22,6 +22,7 @@
 	"dependencies": {
 		"@trpc/server": "^10.6.0",
 		"error-stack-parser": "2.0.7",
+		"firebase-functions": "^4.1.1",
 		"graphql": "15",
 		"graphql-request": "3.7.0",
 		"graphql-tag": "2.12.6",

--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-node/src/client.ts
+++ b/highlight-node/src/client.ts
@@ -135,7 +135,7 @@ export class Highlight {
 					this.lastBackendSetupEvent = Date.now()
 				})
 				.catch((e) => {
-					console.log('highlight-node error: ', e)
+					console.warn('highlight-node error: ', e)
 				})
 		}
 	}
@@ -151,7 +151,7 @@ export class Highlight {
 		try {
 			await this._graphqlSdk.PushBackendPayload(variables)
 		} catch (e) {
-			console.log('highlight-node pushErrors error: ', e)
+			console.warn('highlight-node pushErrors error: ', e)
 		}
 	}
 
@@ -166,7 +166,7 @@ export class Highlight {
 		try {
 			await this._graphqlSdk.PushMetrics(variables)
 		} catch (e) {
-			console.log('highlight-node pushMetrics error: ', e)
+			console.warn('highlight-node pushMetrics error: ', e)
 		}
 	}
 

--- a/highlight-node/src/handlers.ts
+++ b/highlight-node/src/handlers.ts
@@ -1,6 +1,7 @@
 import * as http from 'http'
 import { NodeOptions } from '.'
 import { H, HIGHLIGHT_REQUEST_HEADER } from './sdk.js'
+import * as functions from 'firebase-functions'
 
 /** JSDoc */
 interface MiddlewareError extends Error {
@@ -9,6 +10,22 @@ interface MiddlewareError extends Error {
 	status_code?: number | string
 	output?: {
 		statusCode?: number | string
+	}
+}
+
+function processErrorImpl(options: NodeOptions, req: {headers?: http.IncomingHttpHeaders}, error: Error): void {
+	if (req.headers && req.headers[HIGHLIGHT_REQUEST_HEADER]) {
+		const [secureSessionId, requestId] =
+			`${req.headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
+		if (secureSessionId && requestId) {
+			if (!H.isInitialized()) {
+				H.init(options)
+			}
+			H.consumeEvent(secureSessionId)
+			if (error instanceof Error) {
+				H.consumeError(error, secureSessionId, requestId)
+			}
+		}
 	}
 }
 
@@ -31,21 +48,8 @@ export function errorHandler(
 		next: (error: MiddlewareError) => void,
 	) => {
 		try {
-			if (req.headers && req.headers[HIGHLIGHT_REQUEST_HEADER]) {
-				const [secureSessionId, requestId] =
-					`${req.headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
-				if (secureSessionId && requestId) {
-					if (!H.isInitialized()) {
-						H.init(options)
-					}
-					H.consumeEvent(secureSessionId)
-					if (error instanceof Error) {
-						H.consumeError(error, secureSessionId, requestId)
-					}
-				}
-			}
-			next(error)
-		} catch {
+			processErrorImpl(options, req, error)
+		} finally {
 			next(error)
 		}
 	}
@@ -56,10 +60,59 @@ export function errorHandler(
 /**
  * A TRPC compatible error handler for logging errors to Highlight.
  */
-export async function trpcOnError({ error, req }: {error: Error, req: {headers?: http.IncomingHttpHeaders}}): Promise<void> {
-	if (req.headers && req.headers[HIGHLIGHT_REQUEST_HEADER]) {
-		const [secureSessionId, requestId] = `${req.headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/');
-		H.consumeError(error, secureSessionId, requestId);
+export async function trpcOnError({ error, req }: {error: Error, req: {headers?: http.IncomingHttpHeaders}}, options: NodeOptions = {}): Promise<void> {
+	try {
+		processErrorImpl(options, req, error)
 		await H.flush()
+	} catch (e) {
+		console.log('highlight-node trpcOnError error:', e)
+	}
+}
+
+/**
+ * A wrapper for logging errors to Highlight for Firebase HTTP functions
+ */
+declare type FirebaseHttpFunctionHandler = (req: functions.https.Request, resp: functions.Response<any>) => void | Promise<void>
+export function firebaseHttpFunctionHandler(origHandler: FirebaseHttpFunctionHandler, options: NodeOptions = {}): FirebaseHttpFunctionHandler {
+	return async (req, res) => {
+		try {
+			return await origHandler(req, res)
+		} catch (e) {
+			try {
+				if (e instanceof Error) {
+					processErrorImpl(options, req, e)
+					await H.flush()
+				}
+			} catch (e) {
+				console.log('highlight-node firebaseHttpFunctionHandler error:', e)
+			}
+			
+			// Rethrow the error here to allow any other error handling to happen
+			throw e
+		}
+	}
+}
+
+/**
+ * A wrapper for logging errors to Highlight for Firebase callable functions
+ */
+declare type FirebaseCallableFunctionHandler = (data: any, context: functions.https.CallableContext) => any
+export function firebaseCallableFunctionHandler(origHandler: FirebaseCallableFunctionHandler, options: NodeOptions = {}): FirebaseCallableFunctionHandler {
+	return async (data, context) => {
+		try {
+			return await origHandler(data, context)
+		} catch (e) {
+			try { 
+				if (e instanceof Error) {
+					processErrorImpl(options, context.rawRequest, e)
+					await H.flush()
+				}
+			} catch (e) {
+				console.log('highlight-node firebaseCallableFunctionHandler error:', e)
+			}
+
+			// Rethrow the error here to allow any other error handling to happen
+			throw e
+		}
 	}
 }

--- a/highlight-node/src/handlers.ts
+++ b/highlight-node/src/handlers.ts
@@ -52,3 +52,14 @@ export function errorHandler(
 }
 
 // this code was assisted by https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts
+
+/**
+ * A TRPC compatible error handler for logging errors to Highlight.
+ */
+export async function trpcOnError({ error, req }: {error: Error, req: {headers?: http.IncomingHttpHeaders}}): Promise<void> {
+	if (req.headers && req.headers[HIGHLIGHT_REQUEST_HEADER]) {
+		const [secureSessionId, requestId] = `${req.headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/');
+		H.consumeError(error, secureSessionId, requestId);
+		await H.flush()
+	}
+}

--- a/highlight-node/src/handlers.ts
+++ b/highlight-node/src/handlers.ts
@@ -65,7 +65,7 @@ export async function trpcOnError({ error, req }: {error: Error, req: {headers?:
 		processErrorImpl(options, req, error)
 		await H.flush()
 	} catch (e) {
-		console.log('highlight-node trpcOnError error:', e)
+		console.warn('highlight-node trpcOnError error:', e)
 	}
 }
 
@@ -84,7 +84,7 @@ export function firebaseHttpFunctionHandler(origHandler: FirebaseHttpFunctionHan
 					await H.flush()
 				}
 			} catch (e) {
-				console.log('highlight-node firebaseHttpFunctionHandler error:', e)
+				console.warn('highlight-node firebaseHttpFunctionHandler error:', e)
 			}
 			
 			// Rethrow the error here to allow any other error handling to happen
@@ -108,7 +108,7 @@ export function firebaseCallableFunctionHandler(origHandler: FirebaseCallableFun
 					await H.flush()
 				}
 			} catch (e) {
-				console.log('highlight-node firebaseCallableFunctionHandler error:', e)
+				console.warn('highlight-node firebaseCallableFunctionHandler error:', e)
 			}
 
 			// Rethrow the error here to allow any other error handling to happen

--- a/highlight-node/src/sdk.ts
+++ b/highlight-node/src/sdk.ts
@@ -32,7 +32,7 @@ export const H: HighlightInterface = {
 		try {
 			highlight_obj = new Highlight(options)
 		} catch (e) {
-			console.log('highlight-node init error: ', e)
+			console.warn('highlight-node init error: ', e)
 		}
 	},
 	isInitialized: () => !!highlight_obj,
@@ -44,14 +44,14 @@ export const H: HighlightInterface = {
 		try {
 			highlight_obj.consumeCustomError(error, secureSessionId, requestId)
 		} catch (e) {
-			console.log('highlight-node consumeError error: ', e)
+			console.warn('highlight-node consumeError error: ', e)
 		}
 	},
 	consumeEvent: (secureSessionId: string) => {
 		try {
 			highlight_obj.consumeCustomEvent(secureSessionId)
 		} catch (e) {
-			console.log('highlight-node consumeEvent error: ', e)
+			console.warn('highlight-node consumeEvent error: ', e)
 		}
 	},
 	recordMetric: (
@@ -70,14 +70,14 @@ export const H: HighlightInterface = {
 				tags,
 			)
 		} catch (e) {
-			console.log('highlight-node recordMetric error: ', e)
+			console.warn('highlight-node recordMetric error: ', e)
 		}
 	},
 	flush: async () => {
 		try {
 			await highlight_obj.flush()
 		} catch (e) {
-			console.log('highlight-node flush error: ', e)
+			console.warn('highlight-node flush error: ', e)
 		}
 	},
 	parseHeaders: (
@@ -92,7 +92,7 @@ export const H: HighlightInterface = {
 				}
 			}
 		} catch (e) {
-			console.log('highlight-node parseHeaders error: ', e)
+			console.warn('highlight-node parseHeaders error: ', e)
 		}
 		return undefined
 	},


### PR DESCRIPTION
- tested locally with this code in my `[tprc].ts` file and confirmed backend errors were sent
```
const withHighlight = Highlight();

export default withHighlight(createNextApiHandler({
  router: appRouter,
  createContext,
  batching: {
    enabled: true,
  },
  onError: Handlers.trpcOnError,
}));
```
- tested locally with Firebase callable and http functions, confirmed both were logging errors