### PR TITLE
clean up dependencies

### DIFF
--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -20,9 +20,7 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@trpc/server": "^10.6.0",
 		"error-stack-parser": "2.0.7",
-		"firebase-functions": "^4.1.1",
 		"graphql": "15",
 		"graphql-request": "3.7.0",
 		"graphql-tag": "2.12.6",
@@ -38,6 +36,7 @@
 		"@types/jest": "^29.2.0",
 		"@types/lru-cache": "^7.10.10",
 		"@types/node": "17.0.13",
+		"firebase-functions": "^4.1.1",
 		"jest": "^29.2.2",
 		"ts-jest": "^29.0.3",
 		"tsup": "^6.2.3",


### PR DESCRIPTION
- wasn't paying attention to this initially but I ended up not using the `@trpc/server` dependency and `firebase-functions` can be a dev dependency because it's only used for types