### PR TITLE
[HIG-3534] ensure highlight SDK is initialized before flushing

### DIFF
--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-node/src/handlers.ts
+++ b/highlight-node/src/handlers.ts
@@ -72,6 +72,9 @@ export async function trpcOnError(
 	options: NodeOptions = {},
 ): Promise<void> {
 	try {
+		if (!H.isInitialized()) {
+			H.init(options)
+		}
 		processErrorImpl(options, req, error)
 		await H.flush()
 	} catch (e) {
@@ -96,6 +99,9 @@ export function firebaseHttpFunctionHandler(
 		} catch (e) {
 			try {
 				if (e instanceof Error) {
+					if (!H.isInitialized()) {
+						H.init(options)
+					}
 					processErrorImpl(options, req, e)
 					await H.flush()
 				}
@@ -129,6 +135,9 @@ export function firebaseCallableFunctionHandler(
 		} catch (e) {
 			try {
 				if (e instanceof Error) {
+					if (!H.isInitialized()) {
+						H.init(options)
+					}
 					processErrorImpl(options, context.rawRequest, e)
 					await H.flush()
 				}


### PR DESCRIPTION
- `processErrorImpl` is not guaranteed to call `H.init` if there is no session / request id header passed, call it outside of this function instead
- was considering adding a separate `doFlush` argument to `processErrorImpl`, but then the function would have to be async since flush is. wasn't sure if this breaks compatibility w/ the express function signature
- tested locally w/ Firebase demo app