### PR TITLE
hotfix: replace bundlesize with size-limit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
 		"codegen": "graphql-codegen --config codegen.yml",
 		"dev": "doppler run -- rollup -c -w",
 		"dev:gql": "graphql-codegen --config --watch codegen.yml",
-		"enforce-size": "bundlesize",
+		"enforce-size": "size-limit",
 		"test": "vitest",
 		"typegen": "tsc",
 		"types:check": "tsc"
@@ -36,11 +36,11 @@
 		"@rollup/plugin-json": "^4.1.0",
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@rollup/plugin-replace": "^4.0.0",
+		"@size-limit/file": "^8.1.0",
 		"@types/json-stringify-safe": "^5.0.0",
 		"@types/node": "^16.3.1",
 		"@typescript-eslint/eslint-plugin": "^5.30.0",
 		"@typescript-eslint/parser": "^5.30.0",
-		"bundlesize": "^0.18.1",
 		"eslint": "^8.18.0",
 		"eslint-plugin-simple-import-sort": "^7.0.0",
 		"eslint-plugin-unused-imports": "^2.0.0",
@@ -53,6 +53,7 @@
 		"rollup-plugin-esbuild": "^4.9.1",
 		"rollup-plugin-filesize": "^9.1.2",
 		"rollup-plugin-web-worker-loader": "^1.6.1",
+		"size-limit": "^8.1.0",
 		"typescript": "^4.1.3",
 		"vitest": "^0.24.1"
 	},
@@ -71,10 +72,11 @@
 		"ansi-regex": "5.0.1",
 		"json-schema": "0.4.0"
 	},
-	"bundlesize": [
+	"size-limit": [
 		{
 			"path": "dist/**.js",
-			"maxSize": "300 kB"
+			"limit": "300 kB",
+			"brotli": true
 		}
 	]
 }

--- a/firstload/package.json
+++ b/firstload/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "doppler run -- rollup -c -w",
-		"enforce-size": "bundlesize",
+		"enforce-size": "size-limit",
 		"test": "vitest",
 		"typegen": "tsc"
 	},
@@ -17,22 +17,24 @@
 		"@rollup/plugin-json": "^4.1.0",
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@rollup/plugin-replace": "^4.0.0",
+		"@size-limit/file": "^8.1.0",
 		"@types/chrome": "^0.0.144",
-		"bundlesize": "^0.18.1",
 		"esbuild": "^0.14.47",
 		"rollup": "^2.75.7",
 		"rollup-plugin-consts": "^1.1.0",
 		"rollup-plugin-esbuild": "^4.9.1",
 		"rollup-plugin-filesize": "^9.1.2",
 		"rollup-plugin-web-worker-loader": "^1.6.1",
+		"size-limit": "^8.1.0",
 		"tslib": "^2.4.0",
 		"typescript": "^4.0.3",
 		"vitest": "^0.23.4"
 	},
-	"bundlesize": [
+	"size-limit": [
 		{
 			"path": "dist/**.js",
-			"maxSize": "20 kB"
+			"limit": "26 kB",
+			"brotli": true
 		}
 	]
 }


### PR DESCRIPTION
[Bundlesize](https://github.com/siddharthkp/bundlesize) looks abandoned and has [iltorb](https://github.com/nstepien/iltorb) as a dependency (which was archived on Nov 8, 22). 

This PR makes a switch to size-limit that seems more mature and precise than bundlesize. 