### PR TITLE
[HIG-3490] add list of non-retryable errors

### DIFF
--- a/client/src/graph/generated/operations.ts
+++ b/client/src/graph/generated/operations.ts
@@ -139,6 +139,10 @@ export type MutationPushPayloadArgs = {
 	session_secure_id: Scalars['String']
 }
 
+export enum PublicGraphError {
+	BillingQuotaExceeded = 'BillingQuotaExceeded',
+}
+
 export type Query = {
 	__typename?: 'Query'
 	ignore?: Maybe<Scalars['Any']>

--- a/client/src/graph/generated/schemas.ts
+++ b/client/src/graph/generated/schemas.ts
@@ -136,6 +136,10 @@ export type MutationPushPayloadArgs = {
 	session_secure_id: Scalars['String']
 }
 
+export enum PublicGraphError {
+	BillingQuotaExceeded = 'BillingQuotaExceeded',
+}
+
 export type Query = {
 	__typename?: 'Query'
 	ignore?: Maybe<Scalars['Any']>

--- a/client/src/utils/graph.ts
+++ b/client/src/utils/graph.ts
@@ -1,4 +1,3 @@
-import { GraphQLError } from 'graphql'
 import { ClientError } from 'graphql-request'
 import { PublicGraphError } from '../graph/generated/schemas'
 import { logForHighlight } from './highlight-logging'

--- a/client/src/utils/graph.ts
+++ b/client/src/utils/graph.ts
@@ -1,9 +1,23 @@
+import { GraphQLError } from 'graphql'
+import { ClientError } from 'graphql-request'
+import { PublicGraphError } from '../graph/generated/schemas'
 import { logForHighlight } from './highlight-logging'
 
 export const MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS = 5
 
 // Initial backoff for retrying graphql requests.
 export const INITIAL_BACKOFF = 300
+
+// Do not retry if any of these public graph errors are thrown
+const NON_RETRYABLE_ERRORS = [PublicGraphError.BillingQuotaExceeded.toString()]
+
+// A `ClientError` is retryable if none of the response errors is non-retryable
+const isErrorRetryable = (error: ClientError): boolean => {
+	const match = error.response.errors?.find((e) =>
+		NON_RETRYABLE_ERRORS.includes(e.message),
+	)
+	return match === undefined
+}
 
 export const getGraphQLRequestWrapper = (sessionSecureID: string) => {
 	const graphQLRequestWrapper = async <T>(
@@ -15,6 +29,10 @@ export const getGraphQLRequestWrapper = (sessionSecureID: string) => {
 		try {
 			return await requestFn()
 		} catch (error: any) {
+			if (error instanceof ClientError && !isErrorRetryable(error)) {
+				throw error
+			}
+
 			if (retries < MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS) {
 				await new Promise((resolve) =>
 					setTimeout(resolve, INITIAL_BACKOFF * Math.pow(2, retries)),

--- a/firstload/package.json
+++ b/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.1.8",
+	"version": "5.1.9",
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "doppler run -- rollup -c -w",


### PR DESCRIPTION
- Client should not retry certain errors - added to specifically handle the `BillingQuotaExceeded` case