### PR TITLE
Update `SegmentContext` interface to match Segment's Analytics 2.0 `MiddlewareParams` interface

### DIFF
--- a/firstload/src/integrations/segment.ts
+++ b/firstload/src/integrations/segment.ts
@@ -3,7 +3,7 @@ import type { HighlightPublicInterface } from '../../../client/src/types/types'
 interface SegmentContext {
 	payload: any
 	next: any
-	integrations: any
+	integrations?: any
 }
 
 const HighlightSegmentMiddleware = ({ next, payload }: SegmentContext) => {


### PR DESCRIPTION
Fixes issue for anyone trying to integrate Segment with Highlight (https://www.highlight.io/docs/integrations/segment-integration#Enabling-Track-data-forwarding) when using Typescript.

Have not tested, but seeing how `integrations` isn't actually used anywhere in the code, it should just work.